### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol server for Hackle API providing tools and resources for querying A/B Test data.
 
+<a href="https://glama.ai/mcp/servers/@hackle-io/hackle-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hackle-io/hackle-mcp/badge" alt="hackle-mcp MCP server" />
+</a>
+
 ## Features
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [hackle-mcp](https://glama.ai/mcp/servers/@hackle-io/hackle-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hackle-io/hackle-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hackle-io/hackle-mcp/badge" alt="hackle-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.