### PR TITLE
chore: deprecate local npm package & add registry server.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![smithery badge](https://smithery.ai/badge/@hackle-io/hackle-mcp)](https://smithery.ai/server/@hackle-io/hackle-mcp)
 
-> [!IMPORTANT]
-> ## 🚀 We recommend using the remote MCP server
+> [!WARNING]
+> ## ⚠️ This local npm package is deprecated — use the remote MCP server
 >
-> The Hackle MCP server is now available as a **remote server**. We recommend it over this local npm package — it requires no npm or Node.js setup, updates automatically, and works in the browser. New tools (such as messaging statistics and Kakao/Text message queries) are available on the remote server.
+> The Hackle MCP server is now available as a **remote server**, and this local npm package is **deprecated**. The remote server requires no npm or Node.js setup, updates automatically, works in the browser, and is where all new tools (such as messaging statistics and Kakao/Text message queries) ship.
 >
-> This local server will continue to be supported for the time being, but new development is focused on the remote server.
+> **This package will no longer receive updates or new tools.** Existing installations keep working for now, but please migrate to the remote server.
 >
 > 👉 **Migration guide: https://docs.hackle.io/external-link/model-context-protocol/migration**
 >

--- a/server.json
+++ b/server.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.hackle-io/hackle-mcp",
+  "title": "Hackle",
+  "description": "Remote MCP server exposing the Hackle Admin API as tools (experiments, feature flags, remote config, in-app/push/text messages, analytics, CRM).",
+  "version": "1.0.0",
+  "repository": {
+    "url": "https://github.com/hackle-io/hackle-mcp",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.hackle.io/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
로컬(npm/stdio) 서버를 deprecate 하고, 원격 서버를 공식 MCP Registry에 배포하기 위한 준비입니다.

- **`server.json` 추가** — MCP Registry 등록용. `io.github.hackle-io/hackle-mcp` 네임스페이스, remote(streamable-http) `https://mcp.hackle.io/mcp`. OAuth는 서버의 `.well-known` 디스커버리로 클라이언트가 자동 처리하므로 정적 헤더 미선언.
- **README 안내 강화** — "remote 추천" → "local npm package **deprecated**" 로 톤 변경. 마이그레이션 가이드/연결법은 기존 내용 유지.

## 남은 수동 단계 (이 PR 머지 후)
1. **레지스트리 배포**: `mcp-publisher login github` (hackle-io org) → `mcp-publisher publish`
2. **npm deprecate**: `npm deprecate @hackle-io/hackle-mcp "...remote server..."` (genji-hackle maintainer 권한 확인됨)

## 참고
- 레지스트리는 현재 preview 단계 — GA 전 재배포 필요할 수 있음
- 실제 원격 서버 코드는 내부 GitLab(`commons/hackle-mcp`)에서 운영, 본 레포는 공개 얼굴 + registry 소스로 사용