### PR TITLE
fix: shorten server.json description for registry validation

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.hackle-io/hackle-mcp",
   "title": "Hackle",
-  "description": "Remote MCP server exposing the Hackle Admin API as tools (experiments, feature flags, remote config, in-app/push/text messages, analytics, CRM).",
+  "description": "Remote MCP server for the Hackle Admin API: experiments, feature flags, remote config, messaging.",
   "version": "1.0.0",
   "repository": {
     "url": "https://github.com/hackle-io/hackle-mcp",


### PR DESCRIPTION
MCP Registry는 `description` 최대 100자 제한이 있어 422 validation 에러가 발생했습니다 (기존 143자 → 97자로 단축).

```
Remote MCP server for the Hackle Admin API: experiments, feature flags, remote config, messaging.
```